### PR TITLE
Fix BaseTheme prop value

### DIFF
--- a/src/BoomThemeStyle.ts
+++ b/src/BoomThemeStyle.ts
@@ -1,6 +1,6 @@
 import { CONFIG } from './config';
 export enum BoomThemeStyleProps {
-  BaseTheme = 'theme',
+  BaseTheme = 'basetheme',
   BackgroundImage = 'bgimage',
   CustomStyle = 'style',
   ExternalURL = 'url',


### PR DESCRIPTION
**Problem**

If the base theme is Dark or Light, then we should import the corresponding grafana CSS file. This is currently not working.

**Fix**

The base theme values are not in sync in `config.ts` and in `BoomThemeStyle.ts` files. As a result it's trying to read an empty property from the config and the grafana css file is not imported.

**To reproduce**

Create a new theme and set the base theme as Dark or Light and save it. If you refresh the dashboard and set it to use the new theme then the `@import url( .. grafana-dark/ligh .css)` is not included in the generated HTML.
