### PR TITLE
Fix typo

### DIFF
--- a/src/editors/ThemeEditor.tsx
+++ b/src/editors/ThemeEditor.tsx
@@ -34,7 +34,7 @@ export const ThemeEditor: React.FC<EditorProps> = ({ value, onChange }) => {
   const defaultThemes: SelectableValue[] = [
     { value: 'default', label: 'Default' },
     { value: 'dark', label: 'Dark' },
-    { value: 'light', label: 'light' },
+    { value: 'light', label: 'Light' },
   ];
   return (
     <>


### PR DESCRIPTION
**Problem**

First letter of the light base them is not uppercase 

**Fix**

Uppercase label: `light` -> `Light`

![image](https://user-images.githubusercontent.com/643687/143724023-cbcfa59f-ab8d-4590-ba0c-a7c711671035.png)
